### PR TITLE
ci: add docker build test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,8 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v2
 
+            - name: Touch .env
+              run: touch .env
+
             - name: Build Image
               run: docker buildx bake --set "*.platform=linux/arm/v7,linux/arm64/v8,linux/amd64"


### PR DESCRIPTION
Add docker build test for `arm64`, `amd64`, and `armv7`.