### PR TITLE
feat: add replit support

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,18 @@
+run = "pnpm start >> output.log 2>&1 & pnpx serve ."
+
+[env]
+XDG_CONFIG_HOME = "/home/runner/.config"
+
+[nix]
+channel = "stable-22_05"
+
+[gitHubImport]
+requiredFiles = [".replit", "replit.nix", ".config"]
+
+[languages]
+
+[languages.typescript]
+pattern = "**/{*.ts,*.js,*.tsx,*.jsx}"
+
+[languages.typescript.languageServer]
+start = "typescript-language-server --stdio"

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,9 @@
+{ pkgs }: {
+    deps = [
+        pkgs.esbuild
+        pkgs.nodejs-18_x
+        pkgs.nodePackages.pnpm
+        pkgs.nodePackages.typescript
+        pkgs.nodePackages.typescript-language-server
+    ];
+}


### PR DESCRIPTION
- New distribution: replit.com.
  - Set the env var `WEBHOOK_URL` in left side, then run the replit.
  - It should be able to be "launched" by a simple http GET request.